### PR TITLE
Make Delegation controlled when a defaultDelegate is set.

### DIFF
--- a/contracts/democracy/delegation/DelegationAbstract.sol
+++ b/contracts/democracy/delegation/DelegationAbstract.sol
@@ -1,13 +1,14 @@
 pragma solidity >=0.5.0 <0.6.0;
 
 import "../../deploy/InstanceAbstract.sol";
+import "../../common/Controlled.sol";
 import "./Delegation.sol";
 
 /**
  * @title DelegationAbstract
  * @author Ricardo Guilherme Schmidt (Status Research & Development GmbH). 
  */
-contract DelegationAbstract is InstanceAbstract, Delegation {
+contract DelegationAbstract is InstanceAbstract, Controlled, Delegation {
     struct DelegateSet {
         uint96 fromBlock; //when this was updated
         address to; //who recieved this delegaton

--- a/contracts/democracy/delegation/DelegationBase.sol
+++ b/contracts/democracy/delegation/DelegationBase.sol
@@ -17,13 +17,23 @@ contract DelegationBase is DelegationAbstract {
     }
 
     /** 
-     * @notice Changes the delegation of `msg.sender` to `_to`. if _to 0x00: delegate to self. 
+     * @notice Changes the delegation of `msg.sender` to `_to`. 
      *         In case of having a parent proxy, if never defined, fall back to parent proxy. 
      *         If once defined and want to delegate to parent proxy, set `_to` as parent address. 
      * @param _to To what address the caller address will delegate to.
      */
     function delegate(address _to) external {
         updateDelegate(msg.sender, _to);
+    }
+
+    /** 
+     * @notice Changes the delegation of `address(0)` to `_to`.
+     *         By default accounts delegate to `address(0)`. 
+     *         Therefore the delegate of `address(0)` is the default delegate of all accounts.
+     * @param _defaultDelegate default delegate address
+     */
+    function setDefaultDelegate(address _defaultDelegate) external onlyController {
+        updateDelegate(address(0), _defaultDelegate);
     }
 
     /**

--- a/contracts/democracy/delegation/DelegationFactory.sol
+++ b/contracts/democracy/delegation/DelegationFactory.sol
@@ -27,7 +27,8 @@ contract DelegationFactory is InstanceFactory {
 
     function createDelegation(
         Delegation /*_parent*/,
-        address /*defaultDelegate*/
+        address /*_controller*/,
+        address /*_defaultDelegate*/
     ) 
         external 
         returns (DelegationAbstract instance)

--- a/contracts/democracy/delegation/DelegationInit.sol
+++ b/contracts/democracy/delegation/DelegationInit.sol
@@ -5,35 +5,50 @@ import "./DelegationAbstract.sol";
 /**
  * @title DelegationInit
  * @author Ricardo Guilherme Schmidt (Status Research & Development GmbH)
+ * @notice Initialization Model for Delegation. Is library of functions to initialize instance as Delegation.
  */
 contract DelegationInit is DelegationAbstract {
 
+    modifier notInModel { //avoids control of Init contract
+        require(address(parentDelegation) == address(0), "Bad call"); 
+        _;
+    }
+
+    modifier notImplemented {
+        revert("Wrong model");
+        _;
+    }
+
     /**
-     * @notice Constructor of the model - only knows about watchdog that can trigger upgrade
+     * @notice Constructor of the model
      */
     constructor() public {
         parentDelegation = Delegation(address(-1)); //avoids calling create delegation within the Init contract.
     }
 
     /**
-     * @notice Creates a new Delegation with `_parentDelegation` as default delegation.
+     * @notice Creates a new Delegation with parent as `_parentDelegation` 
+     * @param _parentDelegation lookup delegation of unset users
      */
-    function createDelegation(Delegation _parentDelegation) external {
-        require(address(parentDelegation) == address(0), "Bad call"); //avoids control of Init contract
+    function createDelegation(Delegation _parentDelegation) external notInModel { 
         parentDelegation = _parentDelegation;
     }
 
     /**
      * @notice Creates a new Delegation with `_parentDelegation` as default delegation.
      */
-    function createDelegation(Delegation _parentDelegation, address defaultDelegate) external {
-        require(address(parentDelegation) == address(0), "Bad call"); //avoids control of Init contract
+    function createDelegation(
+        Delegation _parentDelegation, 
+        address payable _controller, 
+        address _defaultDelegate
+    ) external notInModel {
+        controller = _controller; 
         parentDelegation = _parentDelegation;
-        updateDelegate(address(0), defaultDelegate);
+        updateDelegate(address(0), _defaultDelegate);
     }
     
-    function delegate(address) external {}
-    function delegatedTo(address) external view returns (address) {}  
-    function delegatedToAt(address,uint) external view returns (address) {}
+    function delegate(address) external notImplemented {}
+    function delegatedTo(address) external view notImplemented returns (address) {}  
+    function delegatedToAt(address,uint) external view notImplemented returns (address) {}
     
 }

--- a/test/delegation.js
+++ b/test/delegation.js
@@ -54,7 +54,7 @@ contract("DelegationBase", function() {
 
 
     it("creates headless delegation", async function () {
-        let result = await DelegationFactory.methods.createDelegation(utils.zeroAddress,utils.zeroAddress).send();
+        let result = await DelegationFactory.methods.createDelegation(utils.zeroAddress).send();
         var NoDefaultDelegation = new web3.eth.Contract(DelegationBase._jsonInterface, result.events.InstanceCreated.returnValues[0]);
         result = await NoDefaultDelegation.methods.delegatedTo(accounts[0]).call()
         assert.equal(result, utils.zeroAddress)
@@ -63,7 +63,7 @@ contract("DelegationBase", function() {
     })
 
     it("creates root delegation", async function () {
-        let result = await DelegationFactory.methods.createDelegation(utils.zeroAddress,defaultDelegate).send();
+        let result = await DelegationFactory.methods.createDelegation(utils.zeroAddress,defaultDelegate,defaultDelegate).send();
         RootDelegation = new web3.eth.Contract(DelegationBase._jsonInterface, result.events.InstanceCreated.returnValues[0]);
         result = await RootDelegation.methods.delegatedTo(utils.zeroAddress).call()
         assert.equal(result, defaultDelegate)  


### PR DESCRIPTION
This allows a Democracy to control its delegation, for then being able to democratically setting a new default delegate. 